### PR TITLE
Rules set to match GNAT check

### DIFF
--- a/lkql_checker/share/lkql/abort_statements.lkql
+++ b/lkql_checker/share/lkql/abort_statements.lkql
@@ -1,0 +1,2 @@
+@check
+fun abort_statements() = select AbortStmt

--- a/lkql_checker/share/lkql/abstract_types.lkql
+++ b/lkql_checker/share/lkql/abstract_types.lkql
@@ -1,0 +1,11 @@
+fun has_abstract (type_def) =
+    match type_def
+    | r @ RecordTypeDef => r.f_has_abstract?.p_as_bool()
+    | d @ DerivedTypeDef => d.f_has_abstract?.p_as_bool()
+    | p @ PrivateTypeDef => p.f_has_abstract?.p_as_bool()
+    | * => false
+
+@check
+fun abstract_types() =
+    select type @ TypeDef when has_abstract(type)
+

--- a/lkql_checker/share/lkql/blocks.lkql
+++ b/lkql_checker/share/lkql/blocks.lkql
@@ -1,0 +1,3 @@
+@check
+fun blocks() =
+    select BlockStmt

--- a/lkql_checker/share/lkql/function_style_procedures.lkql
+++ b/lkql_checker/share/lkql/function_style_procedures.lkql
@@ -1,0 +1,10 @@
+fun params_in_out(s) =
+    [p for p in s.p_params() if p?.f_mode is ModeInOut]
+
+fun params_out(s) =
+    [p for p in s.p_params() if p?.f_mode is ModeOut]
+
+@check
+fun function_style_procedures() =
+    select sub @ SubpSpec
+    when params_out(sub).length == 1 and params_in_out(sub).length == 0

--- a/testsuite/ada_projects/checks/checks.gpr
+++ b/testsuite/ada_projects/checks/checks.gpr
@@ -1,0 +1,5 @@
+project Checks is
+    for Source_Dirs use ("src");
+    for Object_Dir use "obj";
+    for Main use ("main.adb");
+end Checks;

--- a/testsuite/ada_projects/checks/coding_standard.rules
+++ b/testsuite/ada_projects/checks/coding_standard.rules
@@ -1,2 +1,3 @@
 +R Abort_Statements
++R Abstract_Type_Declarations
 +R Goto_Statements

--- a/testsuite/ada_projects/checks/coding_standard.rules
+++ b/testsuite/ada_projects/checks/coding_standard.rules
@@ -1,4 +1,5 @@
 +R Abort_Statements
 +R Abstract_Type_Declarations
 +R Blocks
++R Function_Style_Procedures
 +R Goto_Statements

--- a/testsuite/ada_projects/checks/coding_standard.rules
+++ b/testsuite/ada_projects/checks/coding_standard.rules
@@ -1,1 +1,2 @@
++R Abort_Statements
 +R Goto_Statements

--- a/testsuite/ada_projects/checks/coding_standard.rules
+++ b/testsuite/ada_projects/checks/coding_standard.rules
@@ -1,0 +1,1 @@
++R Goto_Statements

--- a/testsuite/ada_projects/checks/coding_standard.rules
+++ b/testsuite/ada_projects/checks/coding_standard.rules
@@ -1,3 +1,4 @@
 +R Abort_Statements
 +R Abstract_Type_Declarations
++R Blocks
 +R Goto_Statements

--- a/testsuite/ada_projects/checks/src/abort_statements.adb
+++ b/testsuite/ada_projects/checks/src/abort_statements.adb
@@ -1,0 +1,13 @@
+package body Abort_Statements is
+
+   task T;
+   task body T is
+   begin null;
+   end T;
+
+   procedure Do_Abort is
+   begin
+      abort T; -- FLAG
+   end Do_Abort;
+
+end Abort_Statements;

--- a/testsuite/ada_projects/checks/src/abort_statements.ads
+++ b/testsuite/ada_projects/checks/src/abort_statements.ads
@@ -1,0 +1,5 @@
+package Abort_Statements is
+   
+   procedure Do_Abort;
+
+end Abort_Statements;

--- a/testsuite/ada_projects/checks/src/abstract_type_declarations.ads
+++ b/testsuite/ada_projects/checks/src/abstract_type_declarations.ads
@@ -1,0 +1,9 @@
+package Abstract_Types is
+
+   type Figure is abstract tagged private;              --  FLAG
+   
+private
+   type Figure is abstract tagged null record;          --  FLAG
+   
+   type SubFigure is new Figure with null record;
+end Abstract_Types;

--- a/testsuite/ada_projects/checks/src/blocks.adb
+++ b/testsuite/ada_projects/checks/src/blocks.adb
@@ -1,0 +1,12 @@
+package body Blocks is
+
+   procedure A is
+   begin
+      
+      declare
+      begin
+         null;
+      end;
+   end A;
+
+end Blocks;

--- a/testsuite/ada_projects/checks/src/blocks.ads
+++ b/testsuite/ada_projects/checks/src/blocks.ads
@@ -1,0 +1,5 @@
+package Blocks is
+
+   procedure A;
+
+end Blocks;

--- a/testsuite/ada_projects/checks/src/function_style_procedures.adb
+++ b/testsuite/ada_projects/checks/src/function_style_procedures.adb
@@ -1,0 +1,16 @@
+package body Function_Style_Procedure is
+
+
+   procedure P (R : out Integer) is
+   begin
+      R := 0;
+   end P;
+   
+   procedure P2 (R : out Integer; R2: in out Integer) is
+   begin
+      R := R2;
+      R2 := 0;
+   end P2;
+   
+
+end Function_Style_Procedure;

--- a/testsuite/ada_projects/checks/src/function_style_procedures.ads
+++ b/testsuite/ada_projects/checks/src/function_style_procedures.ads
@@ -1,0 +1,7 @@
+package Function_Style_Procedure is
+
+   procedure P (R : out Integer); -- FLAG
+   
+   procedure P2 (R : out Integer; R2: in out Integer);
+
+end Function_Style_Procedure;

--- a/testsuite/ada_projects/checks/src/goto_statements.adb
+++ b/testsuite/ada_projects/checks/src/goto_statements.adb
@@ -1,0 +1,10 @@
+package body Goto_Statements is
+
+   
+   procedure P is
+   begin
+      goto A;
+      <<A>>
+   end P;
+
+end Goto_Statements;

--- a/testsuite/ada_projects/checks/src/goto_statements.ads
+++ b/testsuite/ada_projects/checks/src/goto_statements.ads
@@ -1,0 +1,5 @@
+package Goto_Statements is
+
+   procedure P;
+
+end Goto_Statements;

--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,0 +1,6 @@
+procedure Main is
+
+begin
+   --  Insert code here.
+   null;
+end Main;

--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,4 +1,5 @@
 with Abort_Statements;
+with Abstract_Type_Declarations;
 with Goto_Statements;
 
 procedure Main is

--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,6 +1,7 @@
 with Abort_Statements;
 with Abstract_Type_Declarations;
 with Blocks;
+with Function_Style_Procedures;
 with Goto_Statements;
 
 procedure Main is

--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,5 +1,6 @@
 with Abort_Statements;
 with Abstract_Type_Declarations;
+with Blocks;
 with Goto_Statements;
 
 procedure Main is

--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,3 +1,4 @@
+with Abort_Statements;
 with Goto_Statements;
 
 procedure Main is

--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,3 +1,5 @@
+with Goto_Statements;
+
 procedure Main is
 
 begin

--- a/testsuite/tests/checks/abort_statements/test.out
+++ b/testsuite/tests/checks/abort_statements/test.out
@@ -1,0 +1,4 @@
+abort_statements.adb:10:7: error: abort_statements - rule violation
+10 |       abort T; -- FLAG
+   |       ^^^^^^^^ 
+

--- a/testsuite/tests/checks/abort_statements/test.yaml
+++ b/testsuite/tests/checks/abort_statements/test.yaml
@@ -1,0 +1,3 @@
+driver: 'checker'
+project: 'checks/checks.gpr'
+rule_name: Abort_Statements

--- a/testsuite/tests/checks/abstract_types/test.out
+++ b/testsuite/tests/checks/abstract_types/test.out
@@ -1,0 +1,8 @@
+abstract_type_declarations.ads:3:19: error: abstract_types - rule violation
+3 |    type Figure is abstract tagged private;              --  FLAG
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^ 
+
+abstract_type_declarations.ads:6:19: error: abstract_types - rule violation
+6 |    type Figure is abstract tagged null record;          --  FLAG
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+

--- a/testsuite/tests/checks/abstract_types/test.yaml
+++ b/testsuite/tests/checks/abstract_types/test.yaml
@@ -1,0 +1,3 @@
+driver: 'checker'
+project: 'checks/checks.gpr'
+rule_name: Abstract_Types

--- a/testsuite/tests/checks/blocks/test.out
+++ b/testsuite/tests/checks/blocks/test.out
@@ -1,0 +1,4 @@
+blocks.adb:6:7: error: blocks - rule violation
+6 |       declare
+  |       ^^^^ 
+

--- a/testsuite/tests/checks/blocks/test.yaml
+++ b/testsuite/tests/checks/blocks/test.yaml
@@ -1,0 +1,3 @@
+driver: 'checker'
+project: 'checks/checks.gpr'
+rule_name: Blocks

--- a/testsuite/tests/checks/function_style_procedures/test.out
+++ b/testsuite/tests/checks/function_style_procedures/test.out
@@ -1,0 +1,8 @@
+function_style_procedures.ads:3:4: error: function_style_procedures - rule violation
+3 |    procedure P (R : out Integer); -- FLAG
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+function_style_procedures.adb:4:4: error: function_style_procedures - rule violation
+4 |    procedure P (R : out Integer) is
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+

--- a/testsuite/tests/checks/function_style_procedures/test.yaml
+++ b/testsuite/tests/checks/function_style_procedures/test.yaml
@@ -1,0 +1,3 @@
+driver: 'checker'
+project: 'checks/checks.gpr'
+rule_name: Function_Style_Procedures

--- a/testsuite/tests/checks/goto_statements/test.out
+++ b/testsuite/tests/checks/goto_statements/test.out
@@ -1,0 +1,4 @@
+goto_statements.adb:6:7: error: goto_statements - rule violation
+6 |       goto A;
+  |       ^^^^^^^ 
+

--- a/testsuite/tests/checks/goto_statements/test.yaml
+++ b/testsuite/tests/checks/goto_statements/test.yaml
@@ -1,0 +1,3 @@
+driver: 'checker'
+project: 'checks/checks.gpr'
+rule_name: GOTO_Statements


### PR DESCRIPTION
The full GNAT check set of rules is available at https://docs.adacore.com/live/wave/asis/html/gnatcheck_rm/gnatcheck_rm/predefined_rules.html

This set of commits aims to implement some of them in LKQL_checker.

+ Abort_Statements
+ Abstract_Types
+ Blocks
+ Function_Style_Procedures 
+ Tests for the GOTO_Statements rule
+ Add a "Checks" Ada project to run basic rules tests on, with an equivalent `coding_standard.rules` set for gnatcheck