### PR TITLE
Rename String_Set to Unbounded_Text_Set

### DIFF
--- a/lkql/extensions/src/lkql-functions.adb
+++ b/lkql/extensions/src/lkql-functions.adb
@@ -47,7 +47,7 @@ package body LKQL.Functions is
       Resolved_Arguments : constant L.Named_Arg_Array
         := Call.P_Resolved_Arguments (Def);
 
-      Names_Seen         : String_Set;
+      Names_Seen         : Unbounded_Text_Set;
       --  TODO: This check for names seen could/should be done at the same time
       --  as resolution of arguments probably.
 

--- a/lkql/extensions/src/lkql-node_data.adb
+++ b/lkql/extensions/src/lkql-node_data.adb
@@ -21,7 +21,7 @@ package body LKQL.Node_Data is
      (Ctx       : Eval_Context;
       Name_Node : L.Identifier;
       Prefix    : Text_Type;
-      White_List : String_Set) return Text_Type;
+      White_List : Unbounded_Text_Set) return Text_Type;
    --  Helper function to check a prefix on an LKQL identifier, and return the
    --  text without the prefix.
 
@@ -117,7 +117,7 @@ package body LKQL.Node_Data is
      (Ctx        : Eval_Context;
       Name_Node  : L.Identifier;
       Prefix     : Text_Type;
-      White_List : String_Set) return Text_Type
+      White_List : Unbounded_Text_Set) return Text_Type
    is
       Text_Name : constant Text_Type := Name_Node.Text;
 

--- a/lkql/extensions/src/lkql-node_data.ads
+++ b/lkql/extensions/src/lkql-node_data.ads
@@ -22,7 +22,7 @@ package LKQL.Node_Data is
    --  An exception will be raised if there is no such property or if the call
    --  arity doesn't match the arity of the property.
 
-   Builtin_Fields, Builtin_Properties : LKQL.String_Utils.String_Set;
+   Builtin_Fields, Builtin_Properties : LKQL.String_Utils.Unbounded_Text_Set;
    --  Builtin fields and properties. Public because used in completion.
    --  TODO: The whole white list thing is a kludge that we want to remove
    --  as soon as the Langkit introspection API handles mapping properties

--- a/lkql/extensions/src/lkql-string_utils.ads
+++ b/lkql/extensions/src/lkql-string_utils.ads
@@ -13,12 +13,12 @@ package LKQL.String_Utils is
    subtype String_Vector is String_Vectors.Vector;
    --  Vector of Unbouted_Text_type values
 
-   package String_Sets is new Ada.Containers.Hashed_Sets
+   package Unbounded_Text_Sets is new Ada.Containers.Hashed_Sets
      (Element_Type        => Unbounded_Text_Type,
       Hash                => Ada.Strings.Wide_Wide_Unbounded.Wide_Wide_Hash,
       Equivalent_Elements => Ada.Strings.Wide_Wide_Unbounded."=");
 
-   subtype String_Set is String_Sets.Set;
+   subtype Unbounded_Text_Set is Unbounded_Text_Sets.Set;
    --  Set of Unbounded_Text_Type values
 
    function Split_Lines (Str : Text_Type) return String_Vectors.Vector;


### PR DESCRIPTION
Following #31 review, the String_Set is not aptly named as it has no Strings as Elements, but instead  Unbounded_Text, which are close enough but are, as their name say, unbounded.

This PR aims to make code more transparent on that side, though I'm wondering if the name is not becoming too verbose then?