### PR TITLE
To_Unbounded_Text (S : String)

### DIFF
--- a/lkql/extensions/src/liblkqllang-implementation-extensions.adb
+++ b/lkql/extensions/src/liblkqllang-implementation-extensions.adb
@@ -157,7 +157,7 @@ package body Liblkqllang.Implementation.Extensions is
               To_Unbounded_String (Member_Name (Field));
          begin
             if not Builtin_Fields.Contains
-              (To_Unbounded_Text (To_Text (Member_Name (Field))))
+              (To_Unbounded_Text (Member_Name (Field)))
             then
                Insert (Val, 1, "f_");
             end if;
@@ -177,7 +177,7 @@ package body Liblkqllang.Implementation.Extensions is
               To_Unbounded_String (Member_Name (Prop));
          begin
             if not Builtin_Fields.Contains
-              (To_Unbounded_Text (To_Text (Member_Name (Prop))))
+              (To_Unbounded_Text (Member_Name (Prop)))
             then
                Insert (Val, 1, "p_");
             end if;

--- a/lkql/extensions/src/lkql-error_handling.adb
+++ b/lkql/extensions/src/lkql-error_handling.adb
@@ -55,7 +55,7 @@ package body LKQL.Error_Handling is
          Error_Data'
            (Eval_Error,
             N.As_LKQL_Node,
-            To_Unbounded_Text (To_Text (Exception_Message (E)))));
+            To_Unbounded_Text (Exception_Message (E))));
    end Raise_From_Exception;
 
    --------------------------

--- a/lkql/extensions/src/lkql-errors.adb
+++ b/lkql/extensions/src/lkql-errors.adb
@@ -76,7 +76,7 @@ package body LKQL.Errors is
    function Error_Description (Error : Error_Data) return Unbounded_Text_Type
    is (case Error.Kind is
           when No_Error =>
-             To_Unbounded_Text ("No error"),
+             To_Unbounded_Text (Text_Type'("No error")),
           when Eval_Error =>
              Error_Description (Error.AST_Node, Error.Short_Message));
 

--- a/lkql/extensions/src/lkql-node_data.adb
+++ b/lkql/extensions/src/lkql-node_data.adb
@@ -217,12 +217,14 @@ package body LKQL.Node_Data is
       return Result;
    end Introspection_Value_Array_From_Args;
 
+   function Unbounded_Text (S : Text_Type) return Unbounded_Text_Type
+      renames To_Unbounded_Text;
 begin
-   Builtin_Fields.Include (To_Unbounded_Text ("parent"));
-   Builtin_Fields.Include (To_Unbounded_Text ("previous_sibling"));
-   Builtin_Fields.Include (To_Unbounded_Text ("next_sibling"));
-   Builtin_Fields.Include (To_Unbounded_Text ("children"));
-   Builtin_Fields.Include (To_Unbounded_Text ("text"));
-   Builtin_Fields.Include (To_Unbounded_Text ("image"));
-   Builtin_Fields.Include (To_Unbounded_Text ("unit"));
+   Builtin_Fields.Include (Unbounded_Text ("parent"));
+   Builtin_Fields.Include (Unbounded_Text ("previous_sibling"));
+   Builtin_Fields.Include (Unbounded_Text ("next_sibling"));
+   Builtin_Fields.Include (Unbounded_Text ("children"));
+   Builtin_Fields.Include (Unbounded_Text ("text"));
+   Builtin_Fields.Include (Unbounded_Text ("image"));
+   Builtin_Fields.Include (Unbounded_Text ("unit"));
 end LKQL.Node_Data;

--- a/lkql/extensions/src/lkql-primitives.adb
+++ b/lkql/extensions/src/lkql-primitives.adb
@@ -732,7 +732,7 @@ package body LKQL.Primitives is
                    Bool_Image (Bool_Val (Val)),
                  when Kind_Node =>
                    (if Node_Val (Val).Get.Is_Null_Node
-                    then To_Unbounded_Text ("null")
+                    then To_Unbounded_Text (Text_Type'("null"))
                     else To_Unbounded_Text (Val.Get.Node_Val.Get.Text_Image)),
                  when Kind_Iterator =>
                    Iterator_Image (Iter_Val (Val).all),

--- a/lkql/extensions/src/lkql-primitives.adb
+++ b/lkql/extensions/src/lkql-primitives.adb
@@ -85,7 +85,7 @@ package body LKQL.Primitives is
       Image : String := Boolean'Image (Value);
    begin
       To_Lower (Image);
-      return To_Unbounded_Text (To_Text (Image));
+      return To_Unbounded_Text (Image);
    end Bool_Image;
 
    -------------------------
@@ -717,7 +717,7 @@ package body LKQL.Primitives is
    begin
       return (case Kind (Val) is
                  when Kind_Unit =>
-                   To_Unbounded_Text (To_Text ("()")),
+                   To_Unbounded_Text (Text_Type'("()")),
                  when Kind_Int  =>
                    Int_Image (Int_Val (Val)),
                  when Kind_Str  =>
@@ -726,8 +726,8 @@ package body LKQL.Primitives is
                     --  to convert it back & forth from string. We should add
                     --  an overload in langkit that returns a Text_Type.
                    To_Unbounded_Text
-                     (To_Text (Image (To_Text (Str_Val (Val)),
-                                      With_Quotes => True))),
+                     (Image (To_Text (Str_Val (Val)),
+                             With_Quotes => True)),
                  when Kind_Bool =>
                    Bool_Image (Bool_Val (Val)),
                  when Kind_Node =>
@@ -743,7 +743,7 @@ package body LKQL.Primitives is
                  when Kind_Selector_List =>
                    Selector_List_Image (Selector_List_Val (Val)),
                  when Kind_Function      => "function "
-              & To_Unbounded_Text (To_Text (Val.Get.Fun_Node.Image)));
+              & To_Unbounded_Text (Val.Get.Fun_Node.Image));
    end To_Unbounded_Text;
 
    ---------------

--- a/lkql/extensions/src/lkql-queries.adb
+++ b/lkql/extensions/src/lkql-queries.adb
@@ -76,8 +76,9 @@ package body LKQL.Queries is
                               (Eval_Error,
                                Node.F_From_Expr.As_LKQL_Node,
                                To_Unbounded_Text
+                                (Text_Type'
                                  ("Wrong kind of element in list for "
-                                  & "`from clause`")));
+                                  & "`from clause`"))));
                         end if;
                         Vec.Append (El.Get.Node_Val);
                      end loop;
@@ -89,7 +90,8 @@ package body LKQL.Queries is
                         (Eval_Error,
                          Node.F_From_Expr.As_LKQL_Node,
                          To_Unbounded_Text
-                           ("Wrong kind of element in `from clause`")));
+                          (Text_Type'
+                           ("Wrong kind of element in `from clause`"))));
                end case;
 
                return new AST_Node_Iterator'Class'

--- a/lkql_checker/src/diagnostics.adb
+++ b/lkql_checker/src/diagnostics.adb
@@ -11,7 +11,7 @@ package body Diagnostics is
    is
    begin
       return Diagnostic'
-        (To_Unbounded_Text (To_Text (Project_Path)), Rules);
+        (To_Unbounded_Text (Project_Path), Rules);
    end Make_Diagnostic_For_Project;
 
    --------------


### PR DESCRIPTION
This PR fixes code for the new `To_Unbounded_Text` overload from AdaCore/langkit#474 (idea from #31), and makes use of it to simplify the code.

There is one major issue that popped-up with that change: the string literals can be both interpreted as `String` or `Text_Type`, which means `To_Unbounded_String ("toto")` becomes ambiguous. IMHO this could be a blocker if we intend on using a lot of calls like this. I'll let you decide wether its worth pursuing.