### PR TITLE
Adapt LKQL after langkit changes

### DIFF
--- a/lkql/extensions/src/ada_ast_nodes.ads
+++ b/lkql/extensions/src/ada_ast_nodes.ads
@@ -6,7 +6,6 @@ with Libadalang.Common;
 with Langkit_Support.Text; use Langkit_Support.Text;
 
 with Ada.Containers; use Ada.Containers;
-with GNATCOLL.Utils; use GNATCOLL.Utils;
 with LKQL.Eval_Contexts; use LKQL.Eval_Contexts;
 with Libadalang.Helpers; use Libadalang.Helpers;
 
@@ -47,7 +46,7 @@ package Ada_AST_Nodes is
      (Ada_AST_Node'(Node => Node.Node.Child (N)));
 
    overriding function Matches_Kind_Name
-     (Node : Ada_AST_Node; Kind_Name : String) return Boolean;
+     (Node : Ada_AST_Node; Kind_Name : Text_Type) return Boolean;
 
    overriding function Is_Field_Name
      (Node : Ada_AST_Node; Name : Text_Type) return Boolean;
@@ -75,10 +74,10 @@ package Ada_AST_Nodes is
    function Make_Ada_AST_Node (Node : Ada_Node) return AST_Node_Rc
    is (Make_AST_Node_Rc (Ada_AST_Node'(Node => Node)));
 
-   function Kind_Names return Unbounded_String_Array;
+   function Kind_Names return Unbounded_Text_Array;
    --  List of all the node kinds' names
 
-   function Kind (Name : String) return Node_Type_Id;
+   function Kind (Name : Text_Type) return Node_Type_Id;
    --  Return the ``Node_Type_Id`` for a given ``Name``
 
    function Make_Eval_Context

--- a/lkql/extensions/src/lkql-ast_nodes.ads
+++ b/lkql/extensions/src/lkql-ast_nodes.ads
@@ -103,7 +103,7 @@ package LKQL.AST_Nodes is
    --  Return the Nth child of 'Node'
 
    function Matches_Kind_Name
-     (Node : AST_Node; Kind_Name : String) return Boolean is abstract;
+     (Node : AST_Node; Kind_Name : Text_Type) return Boolean is abstract;
    --  Return True if 'Node's kind name is 'Kind_Name' or 'Node's type is a
    --  subtype of a type which kind name is 'Kind_Name'.
 

--- a/lkql/extensions/src/lkql-node_data.ads
+++ b/lkql/extensions/src/lkql-node_data.ads
@@ -1,7 +1,6 @@
 with LKQL.AST_Nodes;     use LKQL.AST_Nodes;
 with LKQL.Primitives;    use LKQL.Primitives;
 with LKQL.Eval_Contexts; use LKQL.Eval_Contexts;
-with LKQL.String_Utils;   use LKQL.String_Utils;
 
 with Langkit_Support.Text; use Langkit_Support.Text;
 
@@ -21,13 +20,6 @@ package LKQL.Node_Data is
    --  Evaluate the property designated by 'Property_Name' on 'Receiver'.
    --  An exception will be raised if there is no such property or if the call
    --  arity doesn't match the arity of the property.
-
-   Builtin_Fields, Builtin_Properties : LKQL.String_Utils.String_Set;
-   --  Builtin fields and properties. Public because used in completion.
-   --  TODO: The whole white list thing is a kludge that we want to remove
-   --  as soon as the Langkit introspection API handles mapping properties
-   --  to their prefixed names, and so handles built-in properties and
-   --  fields.
 
 private
 

--- a/lkql/extensions/src/lkql-patterns-nodes.adb
+++ b/lkql/extensions/src/lkql-patterns-nodes.adb
@@ -72,7 +72,7 @@ package body LKQL.Patterns.Nodes is
    is
    begin
       return
-        (if Node.Get.Matches_Kind_Name (To_UTF8 (Pattern.F_Kind_Name.Text))
+        (if Node.Get.Matches_Kind_Name (Pattern.F_Kind_Name.Text)
          then Make_Match_Success (To_Primitive (Node))
          else Match_Failure);
    exception

--- a/testsuite/tests/parser/arith_expr_0/test.out
+++ b/testsuite/tests/parser/arith_expr_0/test.out
@@ -1,7 +1,7 @@
 ArithBinOp
-|left:
+|f_left:
 |  IntegerLiteral: 40
-|op:
+|f_op:
 |  OpPlus
-|right:
+|f_right:
 |  IntegerLiteral: 2

--- a/testsuite/tests/parser/arith_expr_1/test.out
+++ b/testsuite/tests/parser/arith_expr_1/test.out
@@ -1,7 +1,7 @@
 ArithBinOp
-|left:
+|f_left:
 |  IntegerLiteral: 46
-|op:
+|f_op:
 |  OpMinus
-|right:
+|f_right:
 |  IntegerLiteral: 4

--- a/testsuite/tests/parser/arith_expr_2/test.out
+++ b/testsuite/tests/parser/arith_expr_2/test.out
@@ -1,7 +1,7 @@
 ArithBinOp
-|left:
+|f_left:
 |  IntegerLiteral: 21
-|op:
+|f_op:
 |  OpMul
-|right:
+|f_right:
 |  IntegerLiteral: 2

--- a/testsuite/tests/parser/arith_expr_3/test.out
+++ b/testsuite/tests/parser/arith_expr_3/test.out
@@ -1,7 +1,7 @@
 ArithBinOp
-|left:
+|f_left:
 |  IntegerLiteral: 84
-|op:
+|f_op:
 |  OpDiv
-|right:
+|f_right:
 |  IntegerLiteral: 2

--- a/testsuite/tests/parser/assign/test.out
+++ b/testsuite/tests/parser/assign/test.out
@@ -1,11 +1,11 @@
 ValDecl
-|identifier:
+|f_identifier:
 |  Identifier: a
-|value:
+|f_value:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  IntegerLiteral: 2
-|  |op:
+|  |f_op:
 |  |  OpMul
-|  |right:
+|  |f_right:
 |  |  IntegerLiteral: 3

--- a/testsuite/tests/parser/chained_dot_access/test.out
+++ b/testsuite/tests/parser/chained_dot_access/test.out
@@ -1,9 +1,9 @@
 DotAccess
-|receiver:
+|f_receiver:
 |  DotAccess
-|  |receiver:
+|  |f_receiver:
 |  |  Identifier: receiver
-|  |member:
+|  |f_member:
 |  |  Identifier: member1
-|member:
+|f_member:
 |  Identifier: member2

--- a/testsuite/tests/parser/chained_query_pattern/test.out
+++ b/testsuite/tests/parser/chained_query_pattern/test.out
@@ -1,72 +1,72 @@
 Query
-|from_expr: <null>
-|pattern:
+|f_from_expr: <null>
+|f_pattern:
 |  ChainedNodePattern
-|  |first_pattern:
+|  |f_first_pattern:
 |  |  BindingPattern
-|  |  |binding:
+|  |  |f_binding:
 |  |  |  Identifier: k
-|  |  |value_pattern:
+|  |  |f_value_pattern:
 |  |  |  NodeKindPattern
-|  |  |  |kind_name:
+|  |  |  |f_kind_name:
 |  |  |  |  Identifier: KindOne
-|  |chain:
+|  |f_chain:
 |  |  ChainedPatternLinkList
 |  |  |  PropertyLink
-|  |  |  |property:
+|  |  |  |f_property:
 |  |  |  |  FunCall
-|  |  |  |  |name:
+|  |  |  |  |f_name:
 |  |  |  |  |  Identifier: property
-|  |  |  |  |arguments:
+|  |  |  |  |f_arguments:
 |  |  |  |  |  ArgList: <empty list>
-|  |  |  |pattern:
+|  |  |  |f_pattern:
 |  |  |  |  NodeKindPattern
-|  |  |  |  |kind_name:
+|  |  |  |  |f_kind_name:
 |  |  |  |  |  Identifier: KindTwo
 |  |  |  SelectorLink
-|  |  |  |selector:
+|  |  |  |f_selector:
 |  |  |  |  SelectorCall
-|  |  |  |  |quantifier:
+|  |  |  |  |f_quantifier:
 |  |  |  |  |  Identifier: all
-|  |  |  |  |binding: <null>
-|  |  |  |  |selector_identifier:
+|  |  |  |  |f_binding: <null>
+|  |  |  |  |f_selector_identifier:
 |  |  |  |  |  Identifier: sel
-|  |  |  |  |args:
+|  |  |  |  |f_args:
 |  |  |  |  |  NamedArgList: <empty list>
-|  |  |  |pattern:
+|  |  |  |f_pattern:
 |  |  |  |  BindingPattern
-|  |  |  |  |binding:
+|  |  |  |  |f_binding:
 |  |  |  |  |  Identifier: l
-|  |  |  |  |value_pattern:
+|  |  |  |  |f_value_pattern:
 |  |  |  |  |  NodeKindPattern
-|  |  |  |  |  |kind_name:
+|  |  |  |  |  |f_kind_name:
 |  |  |  |  |  |  Identifier: KindThree
 |  |  |  FieldLink
-|  |  |  |field:
+|  |  |  |f_field:
 |  |  |  |  Identifier: field
-|  |  |  |pattern:
+|  |  |  |f_pattern:
 |  |  |  |  FilteredPattern
-|  |  |  |  |pattern:
+|  |  |  |  |f_pattern:
 |  |  |  |  |  NodeKindPattern
-|  |  |  |  |  |kind_name:
+|  |  |  |  |  |f_kind_name:
 |  |  |  |  |  |  Identifier: KindFour
-|  |  |  |  |predicate:
+|  |  |  |  |f_predicate:
 |  |  |  |  |  BinOp
-|  |  |  |  |  |left:
+|  |  |  |  |  |f_left:
 |  |  |  |  |  |  DotCall
-|  |  |  |  |  |  |receiver:
+|  |  |  |  |  |  |f_receiver:
 |  |  |  |  |  |  |  Identifier: k
-|  |  |  |  |  |  |member:
+|  |  |  |  |  |  |f_member:
 |  |  |  |  |  |  |  Identifier: prop
-|  |  |  |  |  |  |arguments:
+|  |  |  |  |  |  |f_arguments:
 |  |  |  |  |  |  |  ArgList: <empty list>
-|  |  |  |  |  |op:
+|  |  |  |  |  |f_op:
 |  |  |  |  |  |  OpAnd
-|  |  |  |  |  |right:
+|  |  |  |  |  |f_right:
 |  |  |  |  |  |  DotCall
-|  |  |  |  |  |  |receiver:
+|  |  |  |  |  |  |f_receiver:
 |  |  |  |  |  |  |  Identifier: l
-|  |  |  |  |  |  |member:
+|  |  |  |  |  |  |f_member:
 |  |  |  |  |  |  |  Identifier: prop
-|  |  |  |  |  |  |arguments:
+|  |  |  |  |  |  |f_arguments:
 |  |  |  |  |  |  |  ArgList: <empty list>

--- a/testsuite/tests/parser/comp_expr_0/test.out
+++ b/testsuite/tests/parser/comp_expr_0/test.out
@@ -1,25 +1,25 @@
 BinOp
-|left:
+|f_left:
 |  RelBinOp
-|  |left:
+|  |f_left:
 |  |  IntegerLiteral: 5
-|  |op:
+|  |f_op:
 |  |  OpEq
-|  |right:
+|  |f_right:
 |  |  IntegerLiteral: 5
-|op:
+|f_op:
 |  OpAnd
-|right:
+|f_right:
 |  RelBinOp
-|  |left:
+|  |f_left:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  IntegerLiteral: 5
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpPlus
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 1
-|  |op:
+|  |f_op:
 |  |  OpNeq
-|  |right:
+|  |f_right:
 |  |  IntegerLiteral: 5

--- a/testsuite/tests/parser/comp_expr_1/test.out
+++ b/testsuite/tests/parser/comp_expr_1/test.out
@@ -1,55 +1,55 @@
 BinOp
-|left:
+|f_left:
 |  BinOp
-|  |left:
+|  |f_left:
 |  |  BinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  RelBinOp
-|  |  |  |left:
+|  |  |  |f_left:
 |  |  |  |  IntegerLiteral: 4
-|  |  |  |op:
+|  |  |  |f_op:
 |  |  |  |  OpLt
-|  |  |  |right:
+|  |  |  |f_right:
 |  |  |  |  IntegerLiteral: 5
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpAnd
-|  |  |right:
+|  |  |f_right:
 |  |  |  RelBinOp
-|  |  |  |left:
+|  |  |  |f_left:
 |  |  |  |  ArithBinOp
-|  |  |  |  |left:
+|  |  |  |  |f_left:
 |  |  |  |  |  IntegerLiteral: 4
-|  |  |  |  |op:
+|  |  |  |  |f_op:
 |  |  |  |  |  OpPlus
-|  |  |  |  |right:
+|  |  |  |  |f_right:
 |  |  |  |  |  IntegerLiteral: 1
-|  |  |  |op:
+|  |  |  |f_op:
 |  |  |  |  OpLeq
-|  |  |  |right:
+|  |  |  |f_right:
 |  |  |  |  IntegerLiteral: 5
-|  |op:
+|  |f_op:
 |  |  OpAnd
-|  |right:
+|  |f_right:
 |  |  RelBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  IntegerLiteral: 5
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpGt
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 4
-|op:
+|f_op:
 |  OpAnd
-|right:
+|f_right:
 |  RelBinOp
-|  |left:
+|  |f_left:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  IntegerLiteral: 5
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpMinus
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 1
-|  |op:
+|  |f_op:
 |  |  OpGeq
-|  |right:
+|  |f_right:
 |  |  IntegerLiteral: 4

--- a/testsuite/tests/parser/concat_0/test.out
+++ b/testsuite/tests/parser/concat_0/test.out
@@ -1,13 +1,13 @@
 ArithBinOp
-|left:
+|f_left:
 |  BinOp
-|  |left:
+|  |f_left:
 |  |  StringLiteral: "Hello"
-|  |op:
+|  |f_op:
 |  |  OpConcat
-|  |right:
+|  |f_right:
 |  |  IntegerLiteral: 39
-|op:
+|f_op:
 |  OpPlus
-|right:
+|f_right:
 |  IntegerLiteral: 3

--- a/testsuite/tests/parser/dot_access_0/test.out
+++ b/testsuite/tests/parser/dot_access_0/test.out
@@ -1,5 +1,5 @@
 DotAccess
-|receiver:
+|f_receiver:
 |  Identifier: receiver
-|member:
+|f_member:
 |  Identifier: member

--- a/testsuite/tests/parser/dot_call/test.out
+++ b/testsuite/tests/parser/dot_call/test.out
@@ -1,19 +1,19 @@
 DotCall
-|receiver:
+|f_receiver:
 |  Identifier: value
-|member:
+|f_member:
 |  Identifier: propertyWithArgs
-|arguments:
+|f_arguments:
 |  ArgList
 |  |  ExprArg
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  StringLiteral: "arg1"
 |  |  ExprArg
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  ArithBinOp
-|  |  |  |left:
+|  |  |  |f_left:
 |  |  |  |  IntegerLiteral: 40
-|  |  |  |op:
+|  |  |  |f_op:
 |  |  |  |  OpPlus
-|  |  |  |right:
+|  |  |  |f_right:
 |  |  |  |  IntegerLiteral: 2

--- a/testsuite/tests/parser/full_selector_call/test.out
+++ b/testsuite/tests/parser/full_selector_call/test.out
@@ -1,19 +1,19 @@
 SelectorCall
-|quantifier:
+|f_quantifier:
 |  Identifier: all
-|binding:
+|f_binding:
 |  Identifier: c
-|selector_identifier:
+|f_selector_identifier:
 |  Identifier: children
-|args:
+|f_args:
 |  NamedArgList
 |  |  NamedArg
-|  |  |arg_name:
+|  |  |f_arg_name:
 |  |  |  Identifier: min_depth
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  IntegerLiteral: 1
 |  |  NamedArg
-|  |  |arg_name:
+|  |  |f_arg_name:
 |  |  |  Identifier: max_depth
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  IntegerLiteral: 3

--- a/testsuite/tests/parser/fun_add_call/test.out
+++ b/testsuite/tests/parser/fun_add_call/test.out
@@ -1,11 +1,11 @@
 FunCall
-|name:
+|f_name:
 |  Identifier: add
-|arguments:
+|f_arguments:
 |  ArgList
 |  |  ExprArg
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  IntegerLiteral: 2
 |  |  ExprArg
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  IntegerLiteral: 40

--- a/testsuite/tests/parser/fun_add_call_named_args/test.out
+++ b/testsuite/tests/parser/fun_add_call_named_args/test.out
@@ -1,15 +1,15 @@
 FunCall
-|name:
+|f_name:
 |  Identifier: add
-|arguments:
+|f_arguments:
 |  ArgList
 |  |  NamedArg
-|  |  |arg_name:
+|  |  |f_arg_name:
 |  |  |  Identifier: x
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  IntegerLiteral: 2
 |  |  NamedArg
-|  |  |arg_name:
+|  |  |f_arg_name:
 |  |  |  Identifier: y
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  IntegerLiteral: 40

--- a/testsuite/tests/parser/fun_add_def/test.out
+++ b/testsuite/tests/parser/fun_add_def/test.out
@@ -1,21 +1,21 @@
 FunDecl
-|name:
+|f_name:
 |  Identifier: add
-|fun_expr:
+|f_fun_expr:
 |  NamedFunction
-|  |parameters:
+|  |f_parameters:
 |  |  ParameterDeclList
 |  |  |  ParameterDecl
-|  |  |  |param_identifier:
+|  |  |  |f_param_identifier:
 |  |  |  |  Identifier: x
 |  |  |  ParameterDecl
-|  |  |  |param_identifier:
+|  |  |  |f_param_identifier:
 |  |  |  |  Identifier: y
-|  |body_expr:
+|  |f_body_expr:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  Identifier: x
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpPlus
-|  |  |right:
+|  |  |f_right:
 |  |  |  Identifier: y

--- a/testsuite/tests/parser/fun_default_params/test.out
+++ b/testsuite/tests/parser/fun_default_params/test.out
@@ -1,34 +1,34 @@
 FunDecl
-|name:
+|f_name:
 |  Identifier: dummy
-|fun_expr:
+|f_fun_expr:
 |  NamedFunction
-|  |parameters:
+|  |f_parameters:
 |  |  ParameterDeclList
 |  |  |  ParameterDecl
-|  |  |  |param_identifier:
+|  |  |  |f_param_identifier:
 |  |  |  |  Identifier: a
 |  |  |  DefaultParam
-|  |  |  |param_identifier:
+|  |  |  |f_param_identifier:
 |  |  |  |  Identifier: b
-|  |  |  |default_expr:
+|  |  |  |f_default_expr:
 |  |  |  |  IntegerLiteral: 40
 |  |  |  DefaultParam
-|  |  |  |param_identifier:
+|  |  |  |f_param_identifier:
 |  |  |  |  Identifier: c
-|  |  |  |default_expr:
+|  |  |  |f_default_expr:
 |  |  |  |  IntegerLiteral: 2
-|  |body_expr:
+|  |f_body_expr:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  ArithBinOp
-|  |  |  |left:
+|  |  |  |f_left:
 |  |  |  |  Identifier: a
-|  |  |  |op:
+|  |  |  |f_op:
 |  |  |  |  OpPlus
-|  |  |  |right:
+|  |  |  |f_right:
 |  |  |  |  Identifier: b
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpPlus
-|  |  |right:
+|  |  |f_right:
 |  |  |  Identifier: c

--- a/testsuite/tests/parser/fun_no_args/test.out
+++ b/testsuite/tests/parser/fun_no_args/test.out
@@ -1,12 +1,12 @@
 FunDecl
-|name:
+|f_name:
 |  Identifier: allNodes
-|fun_expr:
+|f_fun_expr:
 |  NamedFunction
-|  |parameters:
+|  |f_parameters:
 |  |  ParameterDeclList: <empty list>
-|  |body_expr:
+|  |f_body_expr:
 |  |  Query
-|  |  |from_expr: <null>
-|  |  |pattern:
+|  |  |f_from_expr: <null>
+|  |  |f_pattern:
 |  |  |  UniversalPattern

--- a/testsuite/tests/parser/if_then_else/test.out
+++ b/testsuite/tests/parser/if_then_else/test.out
@@ -1,13 +1,13 @@
 IfThenElse
-|condition:
+|f_condition:
 |  DotCall
-|  |receiver:
+|  |f_receiver:
 |  |  Identifier: node
-|  |member:
+|  |f_member:
 |  |  Identifier: property
-|  |arguments:
+|  |f_arguments:
 |  |  ArgList: <empty list>
-|then_expr:
+|f_then_expr:
 |  IntegerLiteral: 1
-|else_expr:
+|f_else_expr:
 |  IntegerLiteral: 0

--- a/testsuite/tests/parser/indexing_0/test.out
+++ b/testsuite/tests/parser/indexing_0/test.out
@@ -1,15 +1,15 @@
 ValDecl
-|identifier:
+|f_identifier:
 |  Identifier: a
-|value:
+|f_value:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  IntegerLiteral: 3
-|  |op:
+|  |f_op:
 |  |  OpMul
-|  |right:
+|  |f_right:
 |  |  Indexing
-|  |  |collection_expr:
+|  |  |f_collection_expr:
 |  |  |  Identifier: value
-|  |  |index_expr:
+|  |  |f_index_expr:
 |  |  |  IntegerLiteral: 0

--- a/testsuite/tests/parser/is_clause_0/test.out
+++ b/testsuite/tests/parser/is_clause_0/test.out
@@ -1,11 +1,11 @@
 IsClause
-|node_expr:
+|f_node_expr:
 |  DotAccess
-|  |receiver:
+|  |f_receiver:
 |  |  Identifier: node
-|  |member:
+|  |f_member:
 |  |  Identifier: field
-|pattern:
+|f_pattern:
 |  NodeKindPattern
-|  |kind_name:
+|  |f_kind_name:
 |  |  Identifier: FieldKind

--- a/testsuite/tests/parser/list_comprehension/test.out
+++ b/testsuite/tests/parser/list_comprehension/test.out
@@ -1,33 +1,33 @@
 ListComprehension
-|expr:
+|f_expr:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  Identifier: x
-|  |op:
+|  |f_op:
 |  |  OpPlus
-|  |right:
+|  |f_right:
 |  |  Identifier: y
-|generators:
+|f_generators:
 |  ListCompAssocList
 |  |  ListCompAssoc
-|  |  |binding_name:
+|  |  |f_binding_name:
 |  |  |  Identifier: x
-|  |  |coll_expr:
+|  |  |f_coll_expr:
 |  |  |  Identifier: valuesList
 |  |  ListCompAssoc
-|  |  |binding_name:
+|  |  |f_binding_name:
 |  |  |  Identifier: y
-|  |  |coll_expr:
+|  |  |f_coll_expr:
 |  |  |  Identifier: valuesList2
-|guard:
+|f_guard:
 |  RelBinOp
-|  |left:
+|  |f_left:
 |  |  DotAccess
-|  |  |receiver:
+|  |  |f_receiver:
 |  |  |  Identifier: x
-|  |  |member:
+|  |  |f_member:
 |  |  |  Identifier: property
-|  |op:
+|  |f_op:
 |  |  OpEq
-|  |right:
+|  |f_right:
 |  |  StringLiteral: "Foo"

--- a/testsuite/tests/parser/log_expr_0/test.out
+++ b/testsuite/tests/parser/log_expr_0/test.out
@@ -1,7 +1,7 @@
 BinOp
-|left:
+|f_left:
 |  BoolLiteralTrue
-|op:
+|f_op:
 |  OpOr
-|right:
+|f_right:
 |  BoolLiteralFalse

--- a/testsuite/tests/parser/log_expr_1/test.out
+++ b/testsuite/tests/parser/log_expr_1/test.out
@@ -1,7 +1,7 @@
 BinOp
-|left:
+|f_left:
 |  BoolLiteralTrue
-|op:
+|f_op:
 |  OpAnd
-|right:
+|f_right:
 |  BoolLiteralFalse

--- a/testsuite/tests/parser/match_expr/test.out
+++ b/testsuite/tests/parser/match_expr/test.out
@@ -1,17 +1,17 @@
 Match
-|matched_val:
+|f_matched_val:
 |  Identifier: node
-|arms:
+|f_arms:
 |  MatchArmList
 |  |  MatchArm
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  NodeKindPattern
-|  |  |  |kind_name:
+|  |  |  |f_kind_name:
 |  |  |  |  Identifier: ObjectDecl
-|  |  |expr:
+|  |  |f_expr:
 |  |  |  BoolLiteralTrue
 |  |  MatchArm
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  UniversalPattern
-|  |  |expr:
+|  |  |f_expr:
 |  |  |  BoolLiteralFalse

--- a/testsuite/tests/parser/not/test.out
+++ b/testsuite/tests/parser/not/test.out
@@ -1,21 +1,21 @@
 IfThenElse
-|condition:
+|f_condition:
 |  NotNode
-|  |value:
+|  |f_value:
 |  |  RelBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  DotCall
-|  |  |  |receiver:
+|  |  |  |f_receiver:
 |  |  |  |  Identifier: node
-|  |  |  |member:
+|  |  |  |f_member:
 |  |  |  |  Identifier: prop
-|  |  |  |arguments:
+|  |  |  |f_arguments:
 |  |  |  |  ArgList: <empty list>
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpGt
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 0
-|then_expr:
+|f_then_expr:
 |  BoolLiteralTrue
-|else_expr:
+|f_else_expr:
 |  BoolLiteralFalse

--- a/testsuite/tests/parser/precedence_div/test.out
+++ b/testsuite/tests/parser/precedence_div/test.out
@@ -1,19 +1,19 @@
 ArithBinOp
-|left:
+|f_left:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  IntegerLiteral: 1
-|  |op:
+|  |f_op:
 |  |  OpPlus
-|  |right:
+|  |f_right:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  IntegerLiteral: 2
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpDiv
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 3
-|op:
+|f_op:
 |  OpPlus
-|right:
+|f_right:
 |  IntegerLiteral: 4

--- a/testsuite/tests/parser/precedence_mul/test.out
+++ b/testsuite/tests/parser/precedence_mul/test.out
@@ -1,19 +1,19 @@
 ArithBinOp
-|left:
+|f_left:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  IntegerLiteral: 1
-|  |op:
+|  |f_op:
 |  |  OpPlus
-|  |right:
+|  |f_right:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  IntegerLiteral: 2
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpMul
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 3
-|op:
+|f_op:
 |  OpPlus
-|right:
+|f_right:
 |  IntegerLiteral: 4

--- a/testsuite/tests/parser/precedence_parenthesis/test.out
+++ b/testsuite/tests/parser/precedence_parenthesis/test.out
@@ -1,19 +1,19 @@
 ArithBinOp
-|left:
+|f_left:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  IntegerLiteral: 1
-|  |op:
+|  |f_op:
 |  |  OpMul
-|  |right:
+|  |f_right:
 |  |  ArithBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  IntegerLiteral: 2
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpPlus
-|  |  |right:
+|  |  |f_right:
 |  |  |  IntegerLiteral: 3
-|op:
+|f_op:
 |  OpMul
-|right:
+|f_right:
 |  IntegerLiteral: 4

--- a/testsuite/tests/parser/query_0/test.out
+++ b/testsuite/tests/parser/query_0/test.out
@@ -1,24 +1,24 @@
 Query
-|from_expr: <null>
-|pattern:
+|f_from_expr: <null>
+|f_pattern:
 |  FilteredPattern
-|  |pattern:
+|  |f_pattern:
 |  |  BindingPattern
-|  |  |binding:
+|  |  |f_binding:
 |  |  |  Identifier: n
-|  |  |value_pattern:
+|  |  |f_value_pattern:
 |  |  |  NodeKindPattern
-|  |  |  |kind_name:
+|  |  |  |f_kind_name:
 |  |  |  |  Identifier: NodeKind
-|  |predicate:
+|  |f_predicate:
 |  |  RelBinOp
-|  |  |left:
+|  |  |f_left:
 |  |  |  DotAccess
-|  |  |  |receiver:
+|  |  |  |f_receiver:
 |  |  |  |  Identifier: n
-|  |  |  |member:
+|  |  |  |f_member:
 |  |  |  |  Identifier: identifier
-|  |  |op:
+|  |  |f_op:
 |  |  |  OpEq
-|  |  |right:
+|  |  |f_right:
 |  |  |  StringLiteral: "Identifier"

--- a/testsuite/tests/parser/query_1/test.out
+++ b/testsuite/tests/parser/query_1/test.out
@@ -1,26 +1,26 @@
 ValDecl
-|identifier:
+|f_identifier:
 |  Identifier: o
-|value:
+|f_value:
 |  Query
-|  |from_expr: <null>
-|  |pattern:
+|  |f_from_expr: <null>
+|  |f_pattern:
 |  |  FilteredPattern
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  BindingPattern
-|  |  |  |binding:
+|  |  |  |f_binding:
 |  |  |  |  Identifier: o
-|  |  |  |value_pattern:
+|  |  |  |f_value_pattern:
 |  |  |  |  NodeKindPattern
-|  |  |  |  |kind_name:
+|  |  |  |  |f_kind_name:
 |  |  |  |  |  Identifier: ObjectDecl
-|  |  |predicate:
+|  |  |f_predicate:
 |  |  |  InClause
-|  |  |  |value_expr:
+|  |  |  |f_value_expr:
 |  |  |  |  DotAccess
-|  |  |  |  |receiver:
+|  |  |  |  |f_receiver:
 |  |  |  |  |  Identifier: o
-|  |  |  |  |member:
+|  |  |  |  |f_member:
 |  |  |  |  |  Identifier: random_field
-|  |  |  |list_expr:
+|  |  |  |f_list_expr:
 |  |  |  |  Identifier: filteredFields

--- a/testsuite/tests/parser/query_binding/test.out
+++ b/testsuite/tests/parser/query_binding/test.out
@@ -1,14 +1,14 @@
 ValDecl
-|identifier:
+|f_identifier:
 |  Identifier: o
-|value:
+|f_value:
 |  Query
-|  |from_expr: <null>
-|  |pattern:
+|  |f_from_expr: <null>
+|  |f_pattern:
 |  |  BindingPattern
-|  |  |binding:
+|  |  |f_binding:
 |  |  |  Identifier: o
-|  |  |value_pattern:
+|  |  |f_value_pattern:
 |  |  |  NodeKindPattern
-|  |  |  |kind_name:
+|  |  |  |f_kind_name:
 |  |  |  |  Identifier: ObjectDecl

--- a/testsuite/tests/parser/query_full_pattern/test.out
+++ b/testsuite/tests/parser/query_full_pattern/test.out
@@ -1,50 +1,50 @@
 ValDecl
-|identifier:
+|f_identifier:
 |  Identifier: declWihAspect
-|value:
+|f_value:
 |  Query
-|  |from_expr: <null>
-|  |pattern:
+|  |f_from_expr: <null>
+|  |f_pattern:
 |  |  FilteredPattern
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  BindingPattern
-|  |  |  |binding:
+|  |  |  |f_binding:
 |  |  |  |  Identifier: o
-|  |  |  |value_pattern:
+|  |  |  |f_value_pattern:
 |  |  |  |  ExtendedNodePattern
-|  |  |  |  |node_pattern:
+|  |  |  |  |f_node_pattern:
 |  |  |  |  |  NodeKindPattern
-|  |  |  |  |  |kind_name:
+|  |  |  |  |  |f_kind_name:
 |  |  |  |  |  |  Identifier: ObjectDecl
-|  |  |  |  |details:
+|  |  |  |  |f_details:
 |  |  |  |  |  NodePatternDetailList
 |  |  |  |  |  |  NodePatternSelector
-|  |  |  |  |  |  |call:
+|  |  |  |  |  |  |f_call:
 |  |  |  |  |  |  |  SelectorCall
-|  |  |  |  |  |  |  |quantifier:
+|  |  |  |  |  |  |  |f_quantifier:
 |  |  |  |  |  |  |  |  Identifier: any
-|  |  |  |  |  |  |  |binding: <null>
-|  |  |  |  |  |  |  |selector_identifier:
+|  |  |  |  |  |  |  |f_binding: <null>
+|  |  |  |  |  |  |  |f_selector_identifier:
 |  |  |  |  |  |  |  |  Identifier: children
-|  |  |  |  |  |  |  |args:
+|  |  |  |  |  |  |  |f_args:
 |  |  |  |  |  |  |  |  NamedArgList: <empty list>
-|  |  |  |  |  |  |pattern:
+|  |  |  |  |  |  |f_pattern:
 |  |  |  |  |  |  |  NodeKindPattern
-|  |  |  |  |  |  |  |kind_name:
+|  |  |  |  |  |  |  |f_kind_name:
 |  |  |  |  |  |  |  |  Identifier: AspectAssoc
-|  |  |predicate:
+|  |  |f_predicate:
 |  |  |  RelBinOp
-|  |  |  |left:
+|  |  |  |f_left:
 |  |  |  |  DotAccess
-|  |  |  |  |receiver:
+|  |  |  |  |f_receiver:
 |  |  |  |  |  DotAccess
-|  |  |  |  |  |receiver:
+|  |  |  |  |  |f_receiver:
 |  |  |  |  |  |  Identifier: o
-|  |  |  |  |  |member:
+|  |  |  |  |  |f_member:
 |  |  |  |  |  |  Identifier: identifier
-|  |  |  |  |member:
+|  |  |  |  |f_member:
 |  |  |  |  |  Identifier: length
-|  |  |  |op:
+|  |  |  |f_op:
 |  |  |  |  OpEq
-|  |  |  |right:
+|  |  |  |f_right:
 |  |  |  |  IntegerLiteral: 42

--- a/testsuite/tests/parser/query_node_kind_only/test.out
+++ b/testsuite/tests/parser/query_node_kind_only/test.out
@@ -1,10 +1,10 @@
 ValDecl
-|identifier:
+|f_identifier:
 |  Identifier: o
-|value:
+|f_value:
 |  Query
-|  |from_expr: <null>
-|  |pattern:
+|  |f_from_expr: <null>
+|  |f_pattern:
 |  |  NodeKindPattern
-|  |  |kind_name:
+|  |  |f_kind_name:
 |  |  |  Identifier: ObjectDecl

--- a/testsuite/tests/parser/query_quantified_selector/test.out
+++ b/testsuite/tests/parser/query_quantified_selector/test.out
@@ -1,28 +1,28 @@
 Query
-|from_expr: <null>
-|pattern:
+|f_from_expr: <null>
+|f_pattern:
 |  BindingPattern
-|  |binding:
+|  |f_binding:
 |  |  Identifier: o
-|  |value_pattern:
+|  |f_value_pattern:
 |  |  ExtendedNodePattern
-|  |  |node_pattern:
+|  |  |f_node_pattern:
 |  |  |  NodeKindPattern
-|  |  |  |kind_name:
+|  |  |  |f_kind_name:
 |  |  |  |  Identifier: ObjectDecl
-|  |  |details:
+|  |  |f_details:
 |  |  |  NodePatternDetailList
 |  |  |  |  NodePatternSelector
-|  |  |  |  |call:
+|  |  |  |  |f_call:
 |  |  |  |  |  SelectorCall
-|  |  |  |  |  |quantifier:
+|  |  |  |  |  |f_quantifier:
 |  |  |  |  |  |  Identifier: all
-|  |  |  |  |  |binding: <null>
-|  |  |  |  |  |selector_identifier:
+|  |  |  |  |  |f_binding: <null>
+|  |  |  |  |  |f_selector_identifier:
 |  |  |  |  |  |  Identifier: children
-|  |  |  |  |  |args:
+|  |  |  |  |  |f_args:
 |  |  |  |  |  |  NamedArgList: <empty list>
-|  |  |  |  |pattern:
+|  |  |  |  |f_pattern:
 |  |  |  |  |  NodeKindPattern
-|  |  |  |  |  |kind_name:
+|  |  |  |  |  |f_kind_name:
 |  |  |  |  |  |  Identifier: AspectAssoc

--- a/testsuite/tests/parser/safe_access/test.out
+++ b/testsuite/tests/parser/safe_access/test.out
@@ -1,5 +1,5 @@
 SafeAccess
-|receiver:
+|f_receiver:
 |  Identifier: receiver
-|member:
+|f_member:
 |  Identifier: member

--- a/testsuite/tests/parser/safe_call/test.out
+++ b/testsuite/tests/parser/safe_call/test.out
@@ -1,19 +1,19 @@
 SafeCall
-|receiver:
+|f_receiver:
 |  Identifier: value
-|member:
+|f_member:
 |  Identifier: propertyWithArgs
-|arguments:
+|f_arguments:
 |  ArgList
 |  |  ExprArg
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  StringLiteral: "arg1"
 |  |  ExprArg
-|  |  |value_expr:
+|  |  |f_value_expr:
 |  |  |  ArithBinOp
-|  |  |  |left:
+|  |  |  |f_left:
 |  |  |  |  IntegerLiteral: 40
-|  |  |  |op:
+|  |  |  |f_op:
 |  |  |  |  OpPlus
-|  |  |  |right:
+|  |  |  |f_right:
 |  |  |  |  IntegerLiteral: 2

--- a/testsuite/tests/parser/selector/test.out
+++ b/testsuite/tests/parser/selector/test.out
@@ -1,69 +1,69 @@
 SelectorDecl
-|name:
+|f_name:
 |  Identifier: testSelector
-|arms:
+|f_arms:
 |  SelectorArmList
 |  |  SelectorArm
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  NodeKindPattern
-|  |  |  |kind_name:
+|  |  |  |f_kind_name:
 |  |  |  |  Identifier: FirstNodeKind
-|  |  |exprs_list:
+|  |  |f_exprs_list:
 |  |  |  SelectorExprList
 |  |  |  |  SelectorExpr
-|  |  |  |  |mode:
+|  |  |  |  |f_mode:
 |  |  |  |  |  SelectorExprModeSkip
-|  |  |  |  |expr:
+|  |  |  |  |f_expr:
 |  |  |  |  |  DotAccess
-|  |  |  |  |  |receiver:
+|  |  |  |  |  |f_receiver:
 |  |  |  |  |  |  Identifier: it
-|  |  |  |  |  |member:
+|  |  |  |  |  |f_member:
 |  |  |  |  |  |  Identifier: field1
 |  |  |  |  SelectorExpr
-|  |  |  |  |mode:
+|  |  |  |  |f_mode:
 |  |  |  |  |  SelectorExprModeRec
-|  |  |  |  |expr:
+|  |  |  |  |f_expr:
 |  |  |  |  |  DotAccess
-|  |  |  |  |  |receiver:
+|  |  |  |  |  |f_receiver:
 |  |  |  |  |  |  Identifier: it
-|  |  |  |  |  |member:
+|  |  |  |  |  |f_member:
 |  |  |  |  |  |  Identifier: field2
 |  |  SelectorArm
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  ExtendedNodePattern
-|  |  |  |node_pattern:
+|  |  |  |f_node_pattern:
 |  |  |  |  NodeKindPattern
-|  |  |  |  |kind_name:
+|  |  |  |  |f_kind_name:
 |  |  |  |  |  Identifier: SecondNodeKind
-|  |  |  |details:
+|  |  |  |f_details:
 |  |  |  |  NodePatternDetailList
 |  |  |  |  |  NodePatternField
-|  |  |  |  |  |identifier:
+|  |  |  |  |  |f_identifier:
 |  |  |  |  |  |  Identifier: children
-|  |  |  |  |  |expected_value:
+|  |  |  |  |  |f_expected_value:
 |  |  |  |  |  |  DetailPattern
-|  |  |  |  |  |  |pattern_value:
+|  |  |  |  |  |  |f_pattern_value:
 |  |  |  |  |  |  |  NodeKindPattern
-|  |  |  |  |  |  |  |kind_name:
+|  |  |  |  |  |  |  |f_kind_name:
 |  |  |  |  |  |  |  |  Identifier: ThirdNodeKind
-|  |  |exprs_list:
+|  |  |f_exprs_list:
 |  |  |  SelectorExprList
 |  |  |  |  SelectorExpr
-|  |  |  |  |mode:
+|  |  |  |  |f_mode:
 |  |  |  |  |  SelectorExprModeDefault
-|  |  |  |  |expr:
+|  |  |  |  |f_expr:
 |  |  |  |  |  DotAccess
-|  |  |  |  |  |receiver:
+|  |  |  |  |  |f_receiver:
 |  |  |  |  |  |  Identifier: it
-|  |  |  |  |  |member:
+|  |  |  |  |  |f_member:
 |  |  |  |  |  |  Identifier: field
 |  |  SelectorArm
-|  |  |pattern:
+|  |  |f_pattern:
 |  |  |  UniversalPattern
-|  |  |exprs_list:
+|  |  |f_exprs_list:
 |  |  |  SelectorExprList
 |  |  |  |  SelectorExpr
-|  |  |  |  |mode:
+|  |  |  |  |f_mode:
 |  |  |  |  |  SelectorExprModeDefault
-|  |  |  |  |expr:
+|  |  |  |  |f_expr:
 |  |  |  |  |  UnitLiteral

--- a/testsuite/tests/parser/universal_pattern/test.out
+++ b/testsuite/tests/parser/universal_pattern/test.out
@@ -1,22 +1,22 @@
 Query
-|from_expr: <null>
-|pattern:
+|f_from_expr: <null>
+|f_pattern:
 |  ExtendedNodePattern
-|  |node_pattern:
+|  |f_node_pattern:
 |  |  UniversalPattern
-|  |details:
+|  |f_details:
 |  |  NodePatternDetailList
 |  |  |  NodePatternSelector
-|  |  |  |call:
+|  |  |  |f_call:
 |  |  |  |  SelectorCall
-|  |  |  |  |quantifier:
+|  |  |  |  |f_quantifier:
 |  |  |  |  |  Identifier: all
-|  |  |  |  |binding: <null>
-|  |  |  |  |selector_identifier:
+|  |  |  |  |f_binding: <null>
+|  |  |  |  |f_selector_identifier:
 |  |  |  |  |  Identifier: children
-|  |  |  |  |args:
+|  |  |  |  |f_args:
 |  |  |  |  |  NamedArgList: <empty list>
-|  |  |  |pattern:
+|  |  |  |f_pattern:
 |  |  |  |  NodeKindPattern
-|  |  |  |  |kind_name:
+|  |  |  |  |f_kind_name:
 |  |  |  |  |  Identifier: BasicDecl

--- a/testsuite/tests/parser/unwrap_call/test.out
+++ b/testsuite/tests/parser/unwrap_call/test.out
@@ -1,9 +1,9 @@
 DotCall
-|receiver:
+|f_receiver:
 |  Unwrap
-|  |node_expr:
+|  |f_node_expr:
 |  |  Identifier: receiver
-|member:
+|f_member:
 |  Identifier: property
-|arguments:
+|f_arguments:
 |  ArgList: <empty list>

--- a/testsuite/tests/parser/val_expr/test.out
+++ b/testsuite/tests/parser/val_expr/test.out
@@ -1,21 +1,21 @@
 BlockExpr
-|vals:
+|f_vals:
 |  ValDeclList
 |  |  ValDecl
-|  |  |identifier:
+|  |  |f_identifier:
 |  |  |  Identifier: x
-|  |  |value:
+|  |  |f_value:
 |  |  |  IntegerLiteral: 40
 |  |  ValDecl
-|  |  |identifier:
+|  |  |f_identifier:
 |  |  |  Identifier: y
-|  |  |value:
+|  |  |f_value:
 |  |  |  IntegerLiteral: 2
-|expr:
+|f_expr:
 |  ArithBinOp
-|  |left:
+|  |f_left:
 |  |  Identifier: x
-|  |op:
+|  |f_op:
 |  |  OpPlus
-|  |right:
+|  |f_right:
 |  |  Identifier: y


### PR DESCRIPTION
The introspection API now include fields prefixes in names, and uses
Text_Type. This allows a number of simplifications in LKQL.