### PR TITLE
"checks" project `main.adb` does not need `with`

### DIFF
--- a/testsuite/ada_projects/checks/src/main.adb
+++ b/testsuite/ada_projects/checks/src/main.adb
@@ -1,9 +1,3 @@
-with Abort_Statements;
-with Abstract_Type_Declarations;
-with Blocks;
-with Function_Style_Procedures;
-with Goto_Statements;
-
 procedure Main is
 
 begin


### PR DESCRIPTION
`gnatcheck` and `lkql_checker` don't take into account the dependency graph to check, so the main does not need to `with` any package.

Keeping the main so the `gpr` file does reference a valid file, but it could probably be removed as well.