### PR TITLE
Add pygments to pip deps

### DIFF
--- a/internal_dev_guide.md
+++ b/internal_dev_guide.md
@@ -31,6 +31,7 @@ git clone git@github.com:AdaCore/langkit-query-language.git
 ```sh
 pip install prompt_toolkit
 pip install railroad-diagrams
+pip install pygments
 ```
 
 ### Environment


### PR DESCRIPTION
The dependency to pygments was missing on the instructions, which means that lkql_repl would not be able to start.

Also that means lkql_repl is a dev tool only, which may or may not make sense.

On a more general note: putting it as a install_requires of liblkqllang python module would be nice, and having a `requirements.txt` is probably a way to go. Tell me if that seem like good ideas, I can do that.