### PR TITLE
Repl empty line is a no-op

### DIFF
--- a/lkql_repl.py
+++ b/lkql_repl.py
@@ -49,7 +49,10 @@ class LKQLCompleter(Completer):
             yield Completion(sym)
 
 
-builtins = {}
+builtins = {
+    # No-Op on empty strings
+    '' : lambda: None,
+}
 global dummy_unit
 
 HELP_MESSAGE = """


### PR DESCRIPTION
Entering empty strings in the repl caused an error, this adds an empty builtin command that does nothing.