### PR TITLE
Fixup function_style_procedures Ada test sources 

### DIFF
--- a/testsuite/ada_projects/checks/src/function_style_procedures.adb
+++ b/testsuite/ada_projects/checks/src/function_style_procedures.adb
@@ -1,4 +1,4 @@
-package body Function_Style_Procedure is
+package body Function_Style_Procedures is
 
 
    procedure P (R : out Integer) is
@@ -13,4 +13,4 @@ package body Function_Style_Procedure is
    end P2;
    
 
-end Function_Style_Procedure;
+end Function_Style_Procedures;

--- a/testsuite/ada_projects/checks/src/function_style_procedures.ads
+++ b/testsuite/ada_projects/checks/src/function_style_procedures.ads
@@ -1,7 +1,7 @@
-package Function_Style_Procedure is
+package Function_Style_Procedures is
 
    procedure P (R : out Integer); -- FLAG
    
    procedure P2 (R : out Integer; R2: in out Integer);
 
-end Function_Style_Procedure;
+end Function_Style_Procedures;


### PR DESCRIPTION
The function_style_procedure adb did not compile and could not be `gnatcheck`'d because of it (typo in package name). 